### PR TITLE
Add marketplace.json for Claude Code plugin system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "mhattingpete-claude-skills",
+  "owner": {
+    "name": "mhattingpete",
+    "email": "noreply@github.com"
+  },
+  "metadata": {
+    "description": "Claude Code Skills for software engineering workflows - Git automation, testing, and code review",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "engineering-workflow-skills",
+      "description": "Skills for common software engineering workflows including git operations, test fixing, and code review implementation",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./git-pushing",
+        "./test-fixing",
+        "./review-implementing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the required `.claude-plugin/marketplace.json` configuration file to enable installation via Claude Code's plugin marketplace system.

## Changes

- Created `.claude-plugin/marketplace.json` with proper plugin structure
- Configured single plugin: `engineering-workflow-skills`
- Registered all three skills: git-pushing, test-fixing, review-implementing

## Testing

After merge, users can install with:
```bash
/plugin marketplace add mhattingpete/claude-skills-marketplace
```

## References

- Follows structure from [anthropics/skills](https://github.com/anthropics/skills)
- Required for plugin marketplace registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)