### PR TITLE
chore(config): add gh CLI auto-install hook for web sessions

### DIFF
--- a/.claude/install-gh.sh
+++ b/.claude/install-gh.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Install gh CLI if not already installed
+if ! command -v gh &> /dev/null; then
+  echo "Installing gh CLI..."
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  sudo apt update
+  sudo apt install gh -y
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "SessionStart": "bash .claude/install-gh.sh"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds SessionStart hook to auto-install gh CLI in Claude Code web sessions
- Includes install script that checks if gh is already installed

## Changes
- Added `.claude/install-gh.sh` - Installation script for gh CLI
- Added/Updated `.claude/settings.json` - SessionStart hook configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)