### PR TITLE
chore(config): migrate SessionStart hook to new matcher format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
-    "SessionStart": "bash .claude/install-gh.sh"
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/install-gh.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Update .claude/settings.json to use the new hook format with matcher-based structure instead of simple strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)