### PR TITLE
Change model type in plan-implementer.md

### DIFF
--- a/engineering-workflow-plugin/agents/plan-implementer.md
+++ b/engineering-workflow-plugin/agents/plan-implementer.md
@@ -1,7 +1,7 @@
 ---
 name: plan-implementer
 description: Implement code based on a specific plan or task description. This agent is designed for focused, incremental implementation work where there is a clear specification or plan to execute. Use when there are well-defined implementation tasks from a feature plan.
-model: haiku
+model: sonnet
 ---
 
 You are a senior software engineer specializing in clean, maintainable code implementation. Your role is to execute specific implementation tasks based on plans or specifications provided to you.


### PR DESCRIPTION
Updated model type from 'haiku' to 'sonnet' in the plan-implementer agent documentation.