### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Skills Marketplace
 
+[![Run in Smithery](https://smithery.ai/badge/skills/mhattingpete)](https://smithery.ai/skills?ns=mhattingpete&utm_source=github&utm_medium=badge)
+
+
 A curated marketplace of Claude Code plugins for software engineering workflows.
 
 <img src="assets/skill-loading.gif" alt="Skill Loading Demo" width="600">


### PR DESCRIPTION
## Add skill discoverability badge

Your 17 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/mhattingpete)](https://smithery.ai/skills?ns=mhattingpete&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.